### PR TITLE
Switch to before_filter to before_action

### DIFF
--- a/app/controllers/dre/devices_controller.rb
+++ b/app/controllers/dre/devices_controller.rb
@@ -2,7 +2,7 @@ require_dependency 'dre/application_controller'
 
 module Dre
   class DevicesController < ApplicationController
-    before_filter :authenticate!
+    before_action :authenticate!
 
     respond_to :json
 


### PR DESCRIPTION
Rails 5.1 deprecates `before_filter` for `before_action`, so the change is needed to support newer versions of Rails.